### PR TITLE
536: Disabling Gradle test task output caching

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -224,6 +224,9 @@ tasks.withType<Test>().configureEach {
     maxParallelForks = 1
     testLogging.showStandardStreams = true
     testLogging.exceptionFormat = TestExceptionFormat.FULL
+
+    // Disable test output caching as these are integration tests and therefore are environment dependent
+    outputs.upToDateWhen { false }
 }
 /* ********************************************* */
 /*                 TEST TASKS                    */


### PR DESCRIPTION
By default, gradle caches the outputs of tasks. If the inputs do not change then when the task is run again the result is returning from the cache.

For test tasks, this means that the tests do not get re-run. To trigger a re-run the clean task must also be supplied, this slows the process down as the code needs to be recompiled

As our tests are integration tests, and are dependent upon an external environment, then caching the results does not make sense.

https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/536