### PR TITLE
736: Allow only sweeping vrp type functional test coverage

### DIFF
--- a/src/test/kotlin/com/forgerock/uk/openbanking/framework/errors/Errors.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/framework/errors/Errors.kt
@@ -14,4 +14,5 @@ const val REQUEST_EXECUTION_TIME_IN_THE_PAST = "Invalid RequestedExecutionDateTi
 const val LOCATION_HEADER_ERROR = "Location header contains an error"
 const val LOCATION_HEADER_NOT_EXISTS = "Location header doesn't exist"
 const val CONSENT_NOT_AUTHORISED = "Resource Owner did not authorize the request"
+const val BAD_REQUEST = "BAD REQUEST"
 

--- a/src/test/kotlin/com/forgerock/uk/openbanking/framework/errors/Errors.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/framework/errors/Errors.kt
@@ -14,5 +14,5 @@ const val REQUEST_EXECUTION_TIME_IN_THE_PAST = "Invalid RequestedExecutionDateTi
 const val LOCATION_HEADER_ERROR = "Location header contains an error"
 const val LOCATION_HEADER_NOT_EXISTS = "Location header doesn't exist"
 const val CONSENT_NOT_AUTHORISED = "Resource Owner did not authorize the request"
-const val BAD_REQUEST = "BAD REQUEST"
+const val BAD_REQUEST = "Bad Request"
 

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/vrp/api/v3_1_10/CreateDomesticVrp.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/vrp/api/v3_1_10/CreateDomesticVrp.kt
@@ -268,40 +268,20 @@ class CreateDomesticVrp(val version: OBVersion, val tppResource: CreateTppCallba
         assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
     }
 
-    fun shouldCreateDomesticVrp_throwsBadRequestHasDifferentVrpTypeOtherThanSweepingTest() {
+    fun shouldCreateDomesticVrpConsent_throwsBadRequestHasDifferentVrpTypeOtherThanSweepingTest() {
         // Given
         val consentRequest = OBDomesticVrpConsentRequestTestDataFactory.aValidOBDomesticVRPConsentRequest()
         consentRequest.data.controlParameters.vrPType = listOf("UK.OBIE.VRPType.Other", "UK.OBIE.VRPType.Sweeping")
-        val (consent, accessToken) = createDomesticVrpConsentsApi.createDomesticVrpConsentAndAuthorize(
-            consentRequest
-        )
-
-        /*assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)*/
-
-        val patchedConsent = getPatchedConsent(consent)
-        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
-
-
-        val paymentSubmissionInvalidVrpType = createPaymentRequest(patchedConsent)
-
-        val signatureWithInvalidVrpType = DefaultJwsSignatureProducer(tppResource.tpp).createDetachedSignature(
-            defaultMapper.writeValueAsString(paymentSubmissionInvalidVrpType)
-        )
-
-        // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
-                .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidVrpType)).sendRequest()
+            createDomesticVrpConsentsApi.createDomesticVrpConsentAndAuthorize(
+                consentRequest
+            )
         }
 
-        // Then
-        val vrPType = consentRequest.data.controlParameters.vrPType
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
         assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(BAD_REQUEST)
-        assertThat(exception.message.toString()).contains("Invalid VRPType, only Sweeping payments are supported" + vrPType)
+        assertThat(exception.message.toString()).contains("[Invalid VRP type, only Sweeping payments are supported.]")
+
     }
 
     fun shouldCreateDomesticVrp_throwsPolicyValidationErrorTest() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/vrp/api/v3_1_10/CreateDomesticVrp.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/vrp/api/v3_1_10/CreateDomesticVrp.kt
@@ -268,7 +268,7 @@ class CreateDomesticVrp(val version: OBVersion, val tppResource: CreateTppCallba
         assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
     }
 
-    fun shouldCreateDomesticVrpConsent_throwsBadRequestHasDifferentVrpTypeOtherThanSweepingTest() {
+    fun shouldCreateDomesticVrpConsent_throwsBadRequestWhenNotSweepingVrpTypeTest() {
         // Given
         val consentRequest = OBDomesticVrpConsentRequestTestDataFactory.aValidOBDomesticVRPConsentRequest()
         consentRequest.data.controlParameters.vrPType = listOf("UK.OBIE.VRPType.Other", "UK.OBIE.VRPType.Sweeping")

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/vrp/junit/v3_1_10/CreateDomesticVrpTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/vrp/junit/v3_1_10/CreateDomesticVrpTest.kt
@@ -112,6 +112,17 @@ class CreateDomesticVrpTest(val tppResource: CreateTppCallback.TppResource) {
         apis = ["domestic-vrps", "domestic-vrp-consents"]
     )
     @Test
+    fun shouldCreateDomesticVrp_throwsBadRequestHasDifferentVrpTypeOtherThanSweeping_v3_1_10() {
+        createDomesticVrpPayment.shouldCreateDomesticVrp_throwsBadRequestHasDifferentVrpTypeOtherThanSweepingTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticVrpPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent"],
+        apis = ["domestic-vrps", "domestic-vrp-consents"]
+    )
+    @Test
     fun shouldCreateDomesticVrp_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_10() {
         createDomesticVrpPayment.shouldCreateDomesticVrp_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBodyTest()
     }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/vrp/junit/v3_1_10/CreateDomesticVrpTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/vrp/junit/v3_1_10/CreateDomesticVrpTest.kt
@@ -112,8 +112,8 @@ class CreateDomesticVrpTest(val tppResource: CreateTppCallback.TppResource) {
         apis = ["domestic-vrps", "domestic-vrp-consents"]
     )
     @Test
-    fun shouldCreateDomesticVrp_throwsBadRequestHasDifferentVrpTypeOtherThanSweeping_v3_1_10() {
-        createDomesticVrpPayment.shouldCreateDomesticVrpConsent_throwsBadRequestHasDifferentVrpTypeOtherThanSweepingTest()
+    fun shouldCreateDomesticVrp_throwsBadRequestWhenNotSweepingVrpType_v3_1_10() {
+        createDomesticVrpPayment.shouldCreateDomesticVrpConsent_throwsBadRequestWhenNotSweepingVrpTypeTest()
     }
 
     @EnabledIfVersion(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/vrp/junit/v3_1_10/CreateDomesticVrpTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/vrp/junit/v3_1_10/CreateDomesticVrpTest.kt
@@ -113,7 +113,7 @@ class CreateDomesticVrpTest(val tppResource: CreateTppCallback.TppResource) {
     )
     @Test
     fun shouldCreateDomesticVrp_throwsBadRequestHasDifferentVrpTypeOtherThanSweeping_v3_1_10() {
-        createDomesticVrpPayment.shouldCreateDomesticVrp_throwsBadRequestHasDifferentVrpTypeOtherThanSweepingTest()
+        createDomesticVrpPayment.shouldCreateDomesticVrpConsent_throwsBadRequestHasDifferentVrpTypeOtherThanSweepingTest()
     }
 
     @EnabledIfVersion(


### PR DESCRIPTION
Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/736
Description: Added the functional test for "allow only sweeping vrp type".