### PR TITLE
805: Calling RCS API via IG route

### DIFF
--- a/gradle/profiles/profile-dev.gradle.kts
+++ b/gradle/profiles/profile-dev.gradle.kts
@@ -44,7 +44,6 @@ val environment by extra("dev")
 val rsServer by extra("https://rs.$environment.forgerock.financial")
 val platformServer by extra("https://iam.$environment.forgerock.financial")
 val amCookieName by extra("iPlanetDirectoryPro")
-val rcsServer by extra("https://rcs.$environment.forgerock.financial")
 val igServer by extra("https://obdemo.$environment.forgerock.financial")
 
 // PSU User configuration

--- a/gradle/profiles/profile-devops.gradle.kts
+++ b/gradle/profiles/profile-devops.gradle.kts
@@ -44,7 +44,6 @@ val environment by extra ("devops")
 val rsServer by extra("https://rs.$environment.forgerock.financial")
 val platformServer by extra("https://iam.$environment.forgerock.financial")
 val amCookieName by extra("iPlanetDirectoryPro")
-val rcsServer by extra("https://rcs.$environment.forgerock.financial")
 val igServer by extra("https://obdemo.$environment.forgerock.financial")
 
 // PSU User configuration

--- a/gradle/profiles/profile-nightly.gradle.kts
+++ b/gradle/profiles/profile-nightly.gradle.kts
@@ -44,7 +44,6 @@ val environment by extra ("nightly")
 val rsServer by extra("https://rs.$environment.forgerock.financial")
 val platformServer by extra("https://iam.$environment.forgerock.financial")
 val amCookieName by extra("80d4a6cdee74c6e")
-val rcsServer by extra("https://rcs.$environment.forgerock.financial")
 val igServer by extra("https://obdemo.$environment.forgerock.financial")
 
 // PSU User configuration

--- a/src/test/kotlin/com/forgerock/securebanking/framework/configuration/Config.kt
+++ b/src/test/kotlin/com/forgerock/securebanking/framework/configuration/Config.kt
@@ -5,7 +5,6 @@ import com.forgerock.uk.openbanking.support.registration.UserRegistrationRequest
 
 val RS_SERVER = System.getenv("rsServer") ?: "https://rs.dev.forgerock.financial"
 val PLATFORM_SERVER = System.getenv("platformServer") ?: "https://iam.dev.forgerock.financial"
-val RCS_SERVER = System.getenv("rcsServer") ?: "https://rcs.dev.forgerock.financial"
 val IG_SERVER = System.getenv("igServer") ?: "https://obdemo.dev.forgerock.financial"
 
 val TRUSTSTORE_PATH = System.getenv("truststorePath") ?: "/com/forgerock/securebanking/truststore.jks"

--- a/src/test/kotlin/com/forgerock/uk/openbanking/support/general/GeneralAS.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/support/general/GeneralAS.kt
@@ -1,7 +1,7 @@
 package com.forgerock.uk.openbanking.support.general
 
+import com.forgerock.securebanking.framework.configuration.IG_SERVER
 import com.forgerock.securebanking.framework.configuration.PLATFORM_SERVER
-import com.forgerock.securebanking.framework.configuration.RCS_SERVER
 import com.forgerock.securebanking.framework.data.*
 import com.forgerock.securebanking.framework.http.fuel.responseObject
 import com.forgerock.securebanking.framework.signature.signPayload
@@ -129,8 +129,9 @@ open class GeneralAS {
         }
     }
 
-    protected fun getConsentDetails(consentRequest: String): String {
-        val (_, response, result) = Fuel.post("$RCS_SERVER/rcs/api/consent/details/")
+    protected fun getConsentDetails(consentRequest: String, cookie: String): String {
+        val (_, response, result) = Fuel.post("$IG_SERVER/rcs/api/consent/details/")
+            .header("Cookie", cookie)
             .body(consentRequest)
             .header("Content-Type", "application/jwt")
             .responseString()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/PaymentAS.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/PaymentAS.kt
@@ -55,7 +55,7 @@ class PaymentAS : GeneralAS() {
         val consentRequest = continueAuthorize(authorizeURL, cookie)
         val consentDetails = getConsentDetails(consentRequest, cookie)
         val debtorAccount = getDebtorAccountFromConsentDetails(consentDetails)
-        val consentDecisionResponse = sendConsentDecision(consentRequest, debtorAccount, decision)
+        val consentDecisionResponse = sendConsentDecision(consentRequest, debtorAccount, decision, cookie)
         val authCode = getAuthCode(consentDecisionResponse.consentJwt, consentDecisionResponse.redirectUri, cookie)
         return exchangeCode(registrationResponse, tpp, authCode)
     }
@@ -78,12 +78,14 @@ class PaymentAS : GeneralAS() {
     private fun sendConsentDecision(
         consentRequest: String,
         consentedAccount: FRFinancialAccount,
-        decision: String
+        decision: String,
+        cookie: String
     ): SendConsentDecisionResponseBody {
         val body = SendConsentDecisionRequestBody(consentRequest, decision, consentedAccount)
         val (_, response, result) = Fuel.post("$IG_SERVER/rcs/api/consent/decision/")
-            .jsonBody(body)
-            .responseObject<SendConsentDecisionResponseBody>()
+                                        .header("Cookie", cookie)
+                                        .jsonBody(body)
+                                        .responseObject<SendConsentDecisionResponseBody>()
         if (!response.isSuccessful) throw AssertionError(
             "Could not send consent decision",
             result.component2()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/PaymentAS.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/PaymentAS.kt
@@ -2,7 +2,7 @@ package com.forgerock.uk.openbanking.support.payment
 
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRFinancialAccount
 import com.forgerock.securebanking.framework.configuration.AM_COOKIE_NAME
-import com.forgerock.securebanking.framework.configuration.RCS_SERVER
+import com.forgerock.securebanking.framework.configuration.IG_SERVER
 import com.forgerock.securebanking.framework.data.AccessToken
 import com.forgerock.securebanking.framework.data.RegistrationResponse
 import com.forgerock.securebanking.framework.data.Tpp
@@ -53,7 +53,7 @@ class PaymentAS : GeneralAS() {
         val authorizeURL = response.successUrl
         val cookie = "$AM_COOKIE_NAME=${response.tokenId}"
         val consentRequest = continueAuthorize(authorizeURL, cookie)
-        val consentDetails = getConsentDetails(consentRequest)
+        val consentDetails = getConsentDetails(consentRequest, cookie)
         val debtorAccount = getDebtorAccountFromConsentDetails(consentDetails)
         val consentDecisionResponse = sendConsentDecision(consentRequest, debtorAccount, decision)
         val authCode = getAuthCode(consentDecisionResponse.consentJwt, consentDecisionResponse.redirectUri, cookie)
@@ -81,7 +81,7 @@ class PaymentAS : GeneralAS() {
         decision: String
     ): SendConsentDecisionResponseBody {
         val body = SendConsentDecisionRequestBody(consentRequest, decision, consentedAccount)
-        val (_, response, result) = Fuel.post("$RCS_SERVER/rcs/api/consent/decision/")
+        val (_, response, result) = Fuel.post("$IG_SERVER/rcs/api/consent/decision/")
             .jsonBody(body)
             .responseObject<SendConsentDecisionResponseBody>()
         if (!response.isSuccessful) throw AssertionError(


### PR DESCRIPTION
- Using IG_SERVER configuration to build RCS API URLs
- Removing RCS_SERVER configuration as it is now redundant
- Updating RCS API calls to supply the AM cookie for authentication purposes

https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/805