### PR TITLE
Functional tests updates for multiple domestic vrps

### DIFF
--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/vrp/api/v3_1_10/GetDomesticVrpDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/vrp/api/v3_1_10/GetDomesticVrpDetails.kt
@@ -1,6 +1,7 @@
 package com.forgerock.uk.openbanking.tests.functional.payment.domestic.vrp.api.v3_1_10
 
 import assertk.assertThat
+import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNotNull
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
@@ -36,12 +37,14 @@ class GetDomesticVrpDetails(
     fun getDomesticVrpDetailsWithMultiplePaymentsTest() {
         // Given
         val consentRequest = OBDomesticVrpConsentRequestTestDataFactory.aValidOBDomesticVRPConsentRequest()
-        val result1 = createDomesticVrpApi.submitPayment(consentRequest)
-        val result2 = createDomesticVrpApi.submitPayment(consentRequest)
+        val payment1 = createDomesticVrpApi.submitPayment(consentRequest)
+        val payment2 = createDomesticVrpApi.submitPayment(consentRequest)
+
+        assertThat(payment1.data.domesticVRPId).isNotEqualTo(payment2.data.domesticVRPId)
 
         // When
-        val domesticVrpDetails1 = getDomesticVrpDetails(result1)
-        val domesticVrpDetails2 = getDomesticVrpDetails(result1)
+        val domesticVrpDetails1 = getDomesticVrpDetails(payment1)
+        val domesticVrpDetails2 = getDomesticVrpDetails(payment2)
 
         // Then
         assertThat(domesticVrpDetails1).isNotNull()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/vrp/api/v3_1_10/GetDomesticVrpDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/vrp/api/v3_1_10/GetDomesticVrpDetails.kt
@@ -33,6 +33,26 @@ class GetDomesticVrpDetails(
         assertThat(domesticVrpDetails.data.paymentStatus).isNotNull()
     }
 
+    fun getDomesticVrpDetailsWithMultiplePaymentsTest() {
+        // Given
+        val consentRequest = OBDomesticVrpConsentRequestTestDataFactory.aValidOBDomesticVRPConsentRequest()
+        val result1 = createDomesticVrpApi.submitPayment(consentRequest)
+        val result2 = createDomesticVrpApi.submitPayment(consentRequest)
+
+        // When
+        val domesticVrpDetails1 = getDomesticVrpDetails(result1)
+        val domesticVrpDetails2 = getDomesticVrpDetails(result1)
+
+        // Then
+        assertThat(domesticVrpDetails1).isNotNull()
+        assertThat(domesticVrpDetails1.data).isNotNull()
+        assertThat(domesticVrpDetails1.data.paymentStatus).isNotNull()
+
+        assertThat(domesticVrpDetails2).isNotNull()
+        assertThat(domesticVrpDetails2.data).isNotNull()
+        assertThat(domesticVrpDetails2.data.paymentStatus).isNotNull()
+    }
+
     fun getDomesticVrpDetails_mandatoryFieldsTest() {
         // Given
         val consentRequest = OBDomesticVrpConsentRequestTestDataFactory.aValidOBDomesticVRPConsentRequest()
@@ -50,7 +70,7 @@ class GetDomesticVrpDetails(
     private fun getDomesticVrpDetails(domesticVrpResponse: OBDomesticVRPResponse): OBWritePaymentDetailsResponse1 {
         val getDomesticVrpDetailsUrl = PaymentFactory.urlWithDomesticVrpPaymentId(
             paymentLinks.GetDomesticVrpPaymentDetails,
-            domesticVrpResponse.data.consentId
+            domesticVrpResponse.data.domesticVRPId
         )
         return paymentApiClient.sendGetRequest(
             getDomesticVrpDetailsUrl,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/vrp/junit/v3_1_10/GetDomesticVrpDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/vrp/junit/v3_1_10/GetDomesticVrpDetailsTest.kt
@@ -36,6 +36,17 @@ class GetDomesticVrpDetailsTest(val tppResource: CreateTppCallback.TppResource) 
         apis = ["domestic-vrps", "domestic-vrp-consents"]
     )
     @Test
+    fun getDomesticVrpDetailsWithMultiplePaymentsTest_v3_1_10() {
+        getDomesticVrpDetails.getDomesticVrpDetailsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetDomesticVrpPayment", "CreateDomesticVrpPayment", "CreateDomesticVRPConsent", "GetDomesticVRPConsent", "GetDomesticVrpPaymentDetails"],
+        apis = ["domestic-vrps", "domestic-vrp-consents"]
+    )
+    @Test
     fun getDomesticVrpDetails_mandatoryFields_v3_1_10() {
         getDomesticVrpDetails.getDomesticVrpDetails_mandatoryFieldsTest()
     }


### PR DESCRIPTION
Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/758

Fixed details query to use domesticVRPId instead of consentId and added a test that submits a payment twice and gets the details for each of the payments.